### PR TITLE
Fix: Implement robust OpenRouter API key validation and error handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -91,10 +91,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Simple validation: make a test request to OpenRouter
         try {
-            const response = await fetch("https://openrouter.ai/api/v1/models", {
+            const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+                method: "POST",
                 headers: {
+                    "Content-Type": "application/json",
                     "Authorization": `Bearer ${key}`,
-                }
+                },
+                body: JSON.stringify({
+                    model: OPENROUTER_MODEL,
+                    messages: [{ role: "user", content: "Hello" }],
+                }),
             });
             if (response.ok) {
                 OPENROUTER_API_KEY = key;
@@ -288,7 +294,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         } catch (error) {
             console.error("Error fetching from OpenRouter:", error);
-            displayError("I'm having trouble connecting to my brain.");
+            orb.classList.add('disturbed');
+            setTimeout(() => {
+                orb.classList.remove('disturbed');
+            }, 300);
+            displayError("There was a problem responding. Please try again.");
             return null;
         } finally {
             orb.classList.remove('responding');


### PR DESCRIPTION
This commit addresses a critical issue where the OpenRouter API key was not being properly validated, and there was no feedback for failed requests.

The following changes were made:
- The `validateApiKey` function now makes a dummy request to OpenRouter to validate the entered key. If the request fails, an error is shown, the orb has a "disturbed" animation, and you are re-prompted for the key.
- The `getAIResponse` function now has more robust error handling. If a request to OpenRouter fails, a graceful fallback message is displayed in the UI, and the orb has a "disturbed" animation.
- The `OPENROUTER_API_KEY` is now correctly used in the `Authorization` header of all requests to OpenRouter.