### PR TITLE
fix: Add required headers to OpenRouter API requests

### DIFF
--- a/script.js
+++ b/script.js
@@ -96,6 +96,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 headers: {
                     "Content-Type": "application/json",
                     "Authorization": `Bearer ${key}`,
+                    "HTTP-Referer": "https://auni.com", // Or your domain
+                    "X-Title": "AUNI", // Or your app name
                 },
                 body: JSON.stringify({
                     model: OPENROUTER_MODEL,
@@ -285,7 +287,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 headers: {
                     "Content-Type": "application/json",
                     "Authorization": `Bearer ${OPENROUTER_API_KEY}`,
-                    "HTTP-Referer": `${window.location.protocol}//${window.location.host}`, // Required by some models
+                    "HTTP-Referer": "https://auni.com", // Or your domain
+                    "X-Title": "AUNI", // Or your app name
                 },
                 body: JSON.stringify({
                     model: OPENROUTER_MODEL,


### PR DESCRIPTION
The application was consistently receiving an 'Invalid API Key' error from OpenRouter, even with a valid key. This was likely due to requests originating from `localhost` being rejected by the API, as some models require a valid `HTTP-Referer` to identify the source application.

This commit fixes the issue by adding the `HTTP-Referer` and `X-Title` headers to the `fetch` calls in both the `validateApiKey` and `getAIResponse` functions. A placeholder domain is used for the referer to ensure that requests are accepted during local development. This change should resolve the misleading authentication error and allow the application to connect to OpenRouter successfully.